### PR TITLE
Remove legacy log, and handling for dry_run parse

### DIFF
--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -357,7 +357,6 @@ create_launch_config(#aws_launch_config{
           ++ when_defined(Monitoring, [{"InstanceMonitoring.Enabled", atom_to_list(Monitoring)}], [])
           ++ member_params("SecurityGroups.member.", SGroups)
           ++ when_defined(KeyPair, [{"KeyName", KeyPair}], []),
-    io:format("~p ~n", [Params]),
     create_launch_config(Params, Config);
 
 create_launch_config(Params, Config) ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -1574,6 +1574,8 @@ maybe_imdsv2_session_token(Config) ->
 %%%%%%%%%%%%%%%%%
 
 % Takes the query response and turns it into a map if desired
+parse_response({ok, Response}, _) when is_atom(Response) ->
+    {ok, Response};
 parse_response({ok, Response}, map) ->
     {ok, _Res} = erlcloud_xml:xml_to_map(Response);
 parse_response({ok, Response}, _) ->


### PR DESCRIPTION
There were a couple of small issues identified in testing by @nkrylov

This PR applies these changes:

1. Remove redundant logging
2. Update `parse_response` to catch when the response is an atom - which is the case for dry runs.